### PR TITLE
use net.JoinHostPort to support using ipv6 addresses

### DIFF
--- a/cmd/sshkeys/main.go
+++ b/cmd/sshkeys/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -90,7 +91,7 @@ func main() {
 			}
 			os.Exit(1)
 		}
-		internalHost += ":22"
+		internalHost = net.JoinHostPort(internalHost, "22")
 	}
 
 	keys, err := sshkeys.GetKeys(internalHost, timeout)


### PR DESCRIPTION
I love this small package. I would like to contribute an improvement:
If i want to scan an ipv6 address:
`λ sshkeys.exe fd13:721e:d424:7777::a34:abcd

'fd13:721e:d424:7777::a34:abcd' is not a valid hostname`

After applying the fix:
`λ sshkeys.exe fd13:721e:d424:7777::a34:abcd

ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPmHu7BIdC5/mUH6eE6SPUtPfDxl3lDHjtewDu8cl8yM
ssh-rsa AAAAB3NzaC1yc...... etc etc`
