### PR TITLE
feat: add more encodings

### DIFF
--- a/sshkeys_test.go
+++ b/sshkeys_test.go
@@ -80,7 +80,7 @@ func TestGetKeys(t *testing.T) {
 		}
 	}()
 
-	keys, err := sshkeys.GetKeys(context.Background(), l.Addr().String(), 4, sshkeys.DefaultKeyAlgorithms()...)
+	keys, err := sshkeys.GetKeys(context.Background(), l.Addr().String(), 4, time.Minute, sshkeys.DefaultKeyAlgorithms()...)
 	require.NoError(t, err)
 
 	fingerprints := make(map[string]string)


### PR DESCRIPTION
## Description

## Problem
The default encoding (in openssh) switched from hex to base64.

## Solution
Add base32 & base64 encoding.

## Notes
The `format` parameter has been removed, there are now two new parameters:
1. `encoding` which controls the encoding (`hex`, `base32`, `base64`)
2. `algorithm` which controls which hash algorithm should be used (`sha1`, `sha256`, `md5`, `authorized_keys`)

Notice that for `authorized_keys` the encoding is not valid.
